### PR TITLE
switch back to the correct requirements.txt for the inference script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-torch>=2.6.0,<3.0.0
-transformers>=4.51.3,<4.52.0
-datasets>=3.5.0,<4.0.0
-trl>=0.16.1,<0.17.0
-click>=8.1.8,<9.0.0
-pandas>=2.2.3,<3.0.0
-deepspeed>=0.16.7,<0.17.0
-hydra-core>=1.3.2,<2.0.0
-pytorch-lightning>=2.5.1.post0,<3.0.0
+transformers==4.51.3 
+safetensors==0.4.3 
+numpy<2
+torch 
+boto3
+click
+pandas


### PR DESCRIPTION
Current requirements.txt doesn't work for the inference script, largely because they require packages that require GPU access (e.g. torch versions). 

Creating this PR for now to revert back to the requirements.txt that works for the inference script, but the two sets of requirements.txt will have to be reconciled to work for both training and inference scripts. 